### PR TITLE
Fix: Occurs error on Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,9 @@ jobs:
 
       - name: Build
         run: |
-          ${{ matrix.cc }} -w --std=c++14 \
-            src/entry/main.cpp \
-            src/dorothy/*.cpp \
-            src/dorothy/parser/*.cpp \
+          ${{ matrix.cc }} -w --std=c++17 \
+            cli/main.cpp \
+            src/*.cpp \
             -o ${{ matrix.binary }}
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix building error on Github Actions,
because of invalid path on workflow.

Task: [54](https://8hzryl7735.execute-api.ap-northeast-1.amazonaws.com/prd/task_app/tasks/54)