### PR TITLE
Fix: Can't update task status

### DIFF
--- a/.github/workflows/update-task-on-merge.yml
+++ b/.github/workflows/update-task-on-merge.yml
@@ -3,7 +3,7 @@ name: Update Task Status on Merge
 on:
   pull_request:
     branches:
-      - develop
+      - develop-llvm
     types:
       - closed
 


### PR DESCRIPTION
Can't update task status when merged,
because invalid branch specified.

Task: [89](https://8hzryl7735.execute-api.ap-northeast-1.amazonaws.com/prd/task_app/tasks/89)